### PR TITLE
Remove systemd service

### DIFF
--- a/debian/lenovo-fccunlock.install
+++ b/debian/lenovo-fccunlock.install
@@ -7,6 +7,5 @@ debian/mm-hook => /usr/lib/x86_64-linux-gnu/ModemManager/fcc-unlock.d/2c7c:6008
 DPR_Fcc_unlock_service /opt/fcc_lenovo/
 libmodemauth.so /opt/fcc_lenovo/lib/
 libmbimtools.so /opt/fcc_lenovo/lib/
-debian/lenovo-fccunlock.service /lib/systemd/system/
 suspend-fix/mm-wrapper.sh /opt/fcc_lenovo/suspend-fix/
 suspend-fix/apply-test-option.conf /etc/systemd/system/ModemManager.service.d/

--- a/debian/lenovo-fccunlock.service
+++ b/debian/lenovo-fccunlock.service
@@ -1,7 +1,0 @@
-[Unit]
-Description=fccunlock
-
-[Service]
-Type=oneshot
-User=root
-ExecStart=/opt/fcc_lenovo/DPR_Fcc_unlock_service

--- a/debian/mm-hook
+++ b/debian/mm-hook
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-systemctl start lenovo-fccunlock
+./opt/fcc_lenovo/DPR_Fcc_unlock_service -v
 exit $?

--- a/debian/mm-hook
+++ b/debian/mm-hook
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-./opt/fcc_lenovo/DPR_Fcc_unlock_service -v
+/opt/fcc_lenovo/DPR_Fcc_unlock_service -v
 exit $?

--- a/debian/rules
+++ b/debian/rules
@@ -14,7 +14,6 @@ override_dh_auto_configure:
 
 override_dh_installsystemd:
 	dh_installsystemd -p lenovo-cfgservice lenovo-cfgservice.service
-	dh_installsystemd -p lenovo-fccunlock lenovo-fccunlock.service --no-enable --no-start
 
 execute_after_dh_install:
 	install -m 0644 -D debian/opt.fcc_lenovo.configservice_lenovo -t debian/lenovo-cfgservice/etc/apparmor.d


### PR DESCRIPTION
https://github.com/lenovo/lenovo-wwan-unlock/issues/33

Remove fcc unlock service information from below files:

rules
lenovo-fccunlock.install

Remove below files:
lenovo-fccunlock.service

And below files could not be removed, 

lenovo-fccunlock.modaliases - Auto installation by platform
lenovo-fccunlock.postinst - Reload when adding the dropin service
lenovo-fccunlock.postrm - Reload when removing the dropin service

