### PR TITLE
Ajust apparmor ruls for fccunlock and configservice

### DIFF
--- a/debian/lenovo-fccunlock.service
+++ b/debian/lenovo-fccunlock.service
@@ -4,4 +4,4 @@ Description=fccunlock
 [Service]
 Type=oneshot
 User=root
-ExecStart=/opt/fcc_lenovo/DPR_Fcc_unlock_service
+ExecStart=/opt/fcc_lenovo/DPR_Fcc_unlock_service -v

--- a/debian/opt.fcc_lenovo.DPR_Fcc_unlock_service
+++ b/debian/opt.fcc_lenovo.DPR_Fcc_unlock_service
@@ -9,16 +9,16 @@ include <tunables/global>
   unix peer=(addr=@mbim-proxy),
 
   /opt/fcc_lenovo/DPR_Fcc_unlock_service mr,
+  /opt/fcc_lenovo/lib/*.so mrix,
+  /usr/bin/cut ix,
   /usr/bin/dash ix,
+  /usr/bin/grep ix,
+  /usr/bin/ls ix,
   /usr/bin/lspci Cx,
   /usr/bin/mmcli ix,
-  /usr/bin/ls ix,
-  /usr/bin/grep ix,
-  /usr/bin/cut ix,
-  /usr/bin/ps Cx,
+  /usr/bin/ps Cx -> ps,
   /usr/sbin/dmidecode Cx,
   /usr/libexec/mbim-proxy mrix,
-  /opt/fcc_lenovo/lib/*.so mrix,
 
   owner /dev/ r,
   owner /dev/wwan0at0 rw,
@@ -26,27 +26,65 @@ include <tunables/global>
   owner /sys/bus/pci/devices/ r,
   owner /sys/devices/pci0000:00/** r,
   owner /sys/devices/virtual/dmi/id/product_family r,
-  owner /sys/firmware/dmi/tables/smbios_entry_point r,
   owner /sys/firmware/dmi/tables/DMI r,
+  owner /sys/firmware/dmi/tables/smbios_entry_point r,
   owner /var/log/fcclock.err w,
   owner /var/log/fcclock.log w,
+
 
   profile /usr/bin/lspci {
     include <abstractions/base>
 
+    capability dac_override,
+    capability dac_read_search,
     capability sys_admin,
 
-    /usr/bin/lspci mr,
+    deny owner /etc/nsswitch.conf r,
+    deny owner /etc/passwd r,
+
     /sys/bus/pci/devices/ r,
     /sys/devices/** r,
+    /usr/bin/lspci mr,
+    /usr/share/misc/pci.ids r,
+
   }
 
   profile /usr/sbin/dmidecode {
     include <abstractions/base>
 
-    /usr/sbin/dmidecode mr,
+    /dev/mem r,
     /sys/firmware/dmi/tables** r,
     /sys/firmware/efi/systab r,
-    /dev/mem r,
+    /usr/sbin/dmidecode mr,
+
+  }
+
+  profile ps {
+    include <abstractions/base>
+    include <abstractions/nameservice>
+
+    # GH: #3079
+    capability dac_override,
+    capability dac_read_search,
+
+    capability sys_ptrace,
+
+    # GH: #3119
+    ptrace (read,trace),
+
+    # LP: #2067319
+    /usr/bin/ps mrix,
+
+    /dev/tty r,
+
+    @{PROC}/ r,
+    @{PROC}/@{pid}/** r,
+    @{PROC}/uptime r,
+    @{PROC}/sys/kernel/** r,
+    # GH: #3079
+    @{PROC}/tty/drivers r,
+    /sys/devices/system/node/ r,
+    /sys/devices/system/node/** r,
+
   }
 }

--- a/debian/opt.fcc_lenovo.configservice_lenovo
+++ b/debian/opt.fcc_lenovo.configservice_lenovo
@@ -9,41 +9,88 @@ include <tunables/global>
   unix peer=(addr=@mbim-proxy),
 
   /opt/fcc_lenovo/configservice_lenovo mr,
+  /opt/fcc_lenovo/lib/*.so mrix,
   /usr/bin/cat ix,
   /usr/bin/dash ix,
   /usr/bin/grep ix,
-  /usr/bin/lspci Cx,
   /usr/bin/ls ix,
-  /usr/bin/ps Cx,
+  /usr/bin/lspci Cx,
+  /usr/bin/mmcli Cx -> mmcli,
+  /usr/bin/ps Cx -> ps,
+  /usr/libexec/mbim-proxy mrix,
   /usr/sbin/dmidecode Cx,
-  /opt/fcc_lenovo/lib/*.so mrix,
 
   owner /dev/ r,
   owner /dev/wwan0at0 rw,
   owner /dev/wwan0mbim0 rw,
-  owner /sys/firmware/dmi/tables/DMI r,
-  owner /sys/firmware/dmi/tables/smbios_entry_point r,
-  owner /sys/devices/virtual/dmi/id/product_family r,
-
   owner /opt/fcc_lenovo/sar_config_files/* r,
   owner /run/* rw,
+  owner /sys/devices/virtual/dmi/id/product_family r,
+  owner /sys/firmware/dmi/tables/DMI r,
+  owner /sys/firmware/dmi/tables/smbios_entry_point r,
+
 
   profile /usr/bin/lspci {
     include <abstractions/base>
 
+    capability dac_override,
+    capability dac_read_search,
     capability sys_admin,
 
-    /usr/bin/lspci mr,
+    deny owner /etc/nsswitch.conf r,
+    deny owner /etc/passwd r,
+
     /sys/bus/pci/devices/ r,
     /sys/devices/** r,
+    /usr/bin/lspci mr,
+    /usr/share/misc/pci.ids r,
+
   }
 
   profile /usr/sbin/dmidecode {
     include <abstractions/base>
 
-    /usr/sbin/dmidecode mr,
+    /dev/mem r,
     /sys/firmware/dmi/tables** r,
     /sys/firmware/efi/systab r,
-    /dev/mem r,
+    /usr/sbin/dmidecode mr,
+
+  }
+
+  profile mmcli {
+    include <abstractions/base>
+    include <abstractions/dbus>
+
+    /usr/bin/mmcli mrix,
+
+  }
+
+  profile ps {
+    include <abstractions/base>
+    include <abstractions/nameservice>
+
+    # GH: #3079
+    capability dac_override,
+    capability dac_read_search,
+
+    capability sys_ptrace,
+
+    # GH: #3119
+    ptrace (read,trace),
+
+    # LP: #2067319
+    /usr/bin/ps mrix,
+
+    /dev/tty r,
+
+    @{PROC}/ r,
+    @{PROC}/@{pid}/** r,
+    @{PROC}/uptime r,
+    @{PROC}/sys/kernel/** r,
+    # GH: #3079
+    @{PROC}/tty/drivers r,
+    /sys/devices/system/node/ r,
+    /sys/devices/system/node/** r,
+
   }
 }

--- a/lenovo-cfgservice.service
+++ b/lenovo-cfgservice.service
@@ -5,7 +5,7 @@ After=ModemManager.service
 [Service]
 Type=simple
 User=root
-ExecStart=/opt/fcc_lenovo/configservice_lenovo
+ExecStart=/opt/fcc_lenovo/configservice_lenovo -v
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartSec=20


### PR DESCRIPTION
* Enable the debug mode by default
* Fix the DENIED info from lspci
* Fix the DENIED info from mmcli
* Fix the unconfined execute permission of ps.(#31)