### PR TITLE
fcc_unlock_setup.sh - remove duplicated variable for identify os

### DIFF
--- a/fcc_unlock_setup.sh
+++ b/fcc_unlock_setup.sh
@@ -19,9 +19,6 @@ fi
 ### Identify current OS
 OS_UBUNTU="Ubuntu"
 OS_FEDORA="Fedora"
-### Identify current OS
-OS_UBUNTU="Ubuntu"
-OS_FEDORA="Fedora"
 
 source /etc/os-release
 echo $NAME


### PR DESCRIPTION
Defined variables for identify os are duplicated.