### PR TITLE
removing --test-quick-suspend-resume

### DIFF
--- a/suspend-fix/mm-wrapper.sh
+++ b/suspend-fix/mm-wrapper.sh
@@ -3,7 +3,6 @@
 
 MM_TEST_OPTIONS=(
 	"--test-low-power-suspend-resume"
-	"--test-quick-suspend-resume"
 )
 
 base_execstart() {


### PR DESCRIPTION
--test-low-power-suspend-resume and --test-quick-suspend-resume will do the exact opposite things.  --test-low-power-suspend-resume will push the modem in Airplane mode (detached from network) while the system is going to suspend. This is exactly what we need for Laptop to save the battery resource.

--test-quick-suspend-resume will make sure that the modem is always connected to network,